### PR TITLE
No sql example

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ AllCops:
   Exclude:
     - spec/**/*.rb
     - test_rails_4_app/**/*.rb
+    - example_rails_app/spec/mocks/*_mock.rb
+    - example_rails_app/db/schema.rb
 Rails:
   Enabled: true
 

--- a/example_rails_app/Gemfile
+++ b/example_rails_app/Gemfile
@@ -3,6 +3,8 @@ source "https://rubygems.org"
 gem "rails", "~>4.2"
 gem "sqlite3"
 group :development, :test do
+  gem "nosql"
+  gem "byebug"
   # gem 'active_mocker', '~>1.7'
   gem "active_mocker", path: "../"
   gem "rspec-rails", "~> 3.0"

--- a/example_rails_app/db/schema.rb
+++ b/example_rails_app/db/schema.rb
@@ -1,5 +1,4 @@
 # encoding: UTF-8
-# frozen_string_literal: true
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,8 +11,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_140_731_144_123) do
-  create_table "comments", force: true do |t|
+ActiveRecord::Schema.define(version: 20140731144123) do
+
+  create_table "comments", force: :cascade do |t|
     t.integer  "user_id"
     t.string   "text"
     t.integer  "votes"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20_140_731_144_123) do
     t.datetime "updated_at"
   end
 
-  create_table "subscriptions", force: true do |t|
+  create_table "subscriptions", force: :cascade do |t|
     t.string   "kind"
     t.integer  "user_id"
     t.boolean  "active"
@@ -29,11 +29,12 @@ ActiveRecord::Schema.define(version: 20_140_731_144_123) do
     t.datetime "updated_at"
   end
 
-  create_table "users", force: true do |t|
+  create_table "users", force: :cascade do |t|
     t.string   "name"
     t.integer  "age"
     t.boolean  "admin"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
 end

--- a/example_rails_app/spec/mocks/comment_mock.rb
+++ b/example_rails_app/spec/mocks/comment_mock.rb
@@ -1,11 +1,8 @@
-# frozen_string_literal: true
-require "active_mocker/mock"
-
-class CommentMock < ActiveMocker::Mock::Base
-  created_with("2.0.0-alpha.0")
+require("active_mocker/mock")
+class CommentMock < ActiveMocker::Base
+  created_with("2.1.3")
   # _modules_constants.erb
-
-  # _class_methods.erb
+  #_class_methods.erb
   class << self
     def attributes
       @attributes ||= HashWithIndifferentAccess.new("id" => nil, "user_id" => nil, "text" => nil, "votes" => nil, "created_at" => nil, "updated_at" => nil).merge(super)
@@ -20,17 +17,16 @@ class CommentMock < ActiveMocker::Mock::Base
     end
 
     def associations_by_class
-      @associations_by_class ||= { User: { belongs_to: [:user] } }.merge(super)
+      @associations_by_class ||= { "User" => { belongs_to: [:user] } }.merge(super)
     end
 
     def mocked_class
       "Comment"
     end
 
-    private :mocked_class
-
+    private(:mocked_class)
     def attribute_names
-      @attribute_names ||= %w(id user_id text votes created_at updated_at) | super
+      @attribute_names ||= (["id", "user_id", "text", "votes", "created_at", "updated_at"] | super)
     end
 
     def primary_key
@@ -44,7 +40,9 @@ class CommentMock < ActiveMocker::Mock::Base
     def table_name
       "comments" || super
     end
+
   end
+
   # _attributes.erb
   def id
     read_attribute(:id)
@@ -95,10 +93,11 @@ class CommentMock < ActiveMocker::Mock::Base
   end
 
   # _associations.erb
-
   # belongs_to
   def user
-    read_association(:user) || write_association(:user, classes("User").try { |k| k.find_by(id: user_id) })
+    read_association(:user) || write_association(:user, classes("User").try do |k|
+      k.find_by(id: user_id)
+    end)
   end
 
   def user=(val)
@@ -108,29 +107,34 @@ class CommentMock < ActiveMocker::Mock::Base
 
   def build_user(attributes = {}, &block)
     association = classes("User").try(:new, attributes, &block)
-    write_association(:user, association) unless association.nil?
+    unless association.nil?
+      write_association(:user, association)
+    end
+
   end
 
   def create_user(attributes = {}, &block)
     association = classes("User").try(:create, attributes, &block)
-    write_association(:user, association) unless association.nil?
-  end
-  alias create_user! create_user
+    unless association.nil?
+      write_association(:user, association)
+    end
 
+  end
+
+  alias_method(:create_user!, :create_user)
   # _scopes.erb
   module Scopes
-    include ActiveMocker::Base::Scopes
+    include(ActiveMocker::Base::Scopes)
   end
 
-  extend Scopes
-
+  extend(Scopes)
   class ScopeRelation < ActiveMocker::Association
-    include CommentMock::Scopes
+    include(CommentMock::Scopes)
   end
 
   def self.__new_relation__(collection)
     CommentMock::ScopeRelation.new(collection)
   end
 
-  private_class_method :__new_relation__
+  private_class_method(:__new_relation__)
 end

--- a/example_rails_app/spec/mocks/subscription_mock.rb
+++ b/example_rails_app/spec/mocks/subscription_mock.rb
@@ -1,11 +1,8 @@
-# frozen_string_literal: true
-require "active_mocker/mock"
-
+require("active_mocker/mock")
 class SubscriptionMock < ActiveMocker::Base
-  created_with("2.0.0-alpha.0")
+  created_with("2.1.3")
   # _modules_constants.erb
-
-  # _class_methods.erb
+  #_class_methods.erb
   class << self
     def attributes
       @attributes ||= HashWithIndifferentAccess.new("id" => nil, "kind" => nil, "user_id" => nil, "active" => nil, "created_at" => nil, "updated_at" => nil).merge(super)
@@ -20,17 +17,16 @@ class SubscriptionMock < ActiveMocker::Base
     end
 
     def associations_by_class
-      @associations_by_class ||= { User: { belongs_to: [:user] } }.merge(super)
+      @associations_by_class ||= { "User" => { belongs_to: [:user] } }.merge(super)
     end
 
     def mocked_class
       "Subscription"
     end
 
-    private :mocked_class
-
+    private(:mocked_class)
     def attribute_names
-      @attribute_names ||= %w(id kind user_id active created_at updated_at) | super
+      @attribute_names ||= (["id", "kind", "user_id", "active", "created_at", "updated_at"] | super)
     end
 
     def primary_key
@@ -44,7 +40,9 @@ class SubscriptionMock < ActiveMocker::Base
     def table_name
       "subscriptions" || super
     end
+
   end
+
   # _attributes.erb
   def id
     read_attribute(:id)
@@ -95,10 +93,11 @@ class SubscriptionMock < ActiveMocker::Base
   end
 
   # _associations.erb
-
   # belongs_to
   def user
-    read_association(:user) || write_association(:user, classes("User").try { |k| k.find_by(id: user_id) })
+    read_association(:user) || write_association(:user, classes("User").try do |k|
+      k.find_by(id: user_id)
+    end)
   end
 
   def user=(val)
@@ -108,29 +107,34 @@ class SubscriptionMock < ActiveMocker::Base
 
   def build_user(attributes = {}, &block)
     association = classes("User").try(:new, attributes, &block)
-    write_association(:user, association) unless association.nil?
+    unless association.nil?
+      write_association(:user, association)
+    end
+
   end
 
   def create_user(attributes = {}, &block)
     association = classes("User").try(:create, attributes, &block)
-    write_association(:user, association) unless association.nil?
-  end
-  alias create_user! create_user
+    unless association.nil?
+      write_association(:user, association)
+    end
 
+  end
+
+  alias_method(:create_user!, :create_user)
   # _scopes.erb
   module Scopes
-    include ActiveMocker::Base::Scopes
+    include(ActiveMocker::Base::Scopes)
   end
 
-  extend Scopes
-
+  extend(Scopes)
   class ScopeRelation < ActiveMocker::Association
-    include SubscriptionMock::Scopes
+    include(SubscriptionMock::Scopes)
   end
 
   def self.__new_relation__(collection)
     SubscriptionMock::ScopeRelation.new(collection)
   end
 
-  private_class_method :__new_relation__
+  private_class_method(:__new_relation__)
 end

--- a/example_rails_app/spec/mocks/user_mock.rb
+++ b/example_rails_app/spec/mocks/user_mock.rb
@@ -1,11 +1,8 @@
-# frozen_string_literal: true
-require "active_mocker/mock"
-
+require("active_mocker/mock")
 class UserMock < ActiveMocker::Base
-  created_with("2.0.0-alpha.0")
+  created_with("2.1.3")
   # _modules_constants.erb
-
-  # _class_methods.erb
+  #_class_methods.erb
   class << self
     def attributes
       @attributes ||= HashWithIndifferentAccess.new("id" => nil, "name" => nil, "age" => nil, "admin" => nil, "created_at" => nil, "updated_at" => nil).merge(super)
@@ -20,17 +17,16 @@ class UserMock < ActiveMocker::Base
     end
 
     def associations_by_class
-      @associations_by_class ||= { Comment: { has_many: [:comments] }, Subscription: { has_many: [:subscriptions] } }.merge(super)
+      @associations_by_class ||= { "Comment" => { has_many: [:comments] }, "Subscription" => { has_many: [:subscriptions] } }.merge(super)
     end
 
     def mocked_class
       "User"
     end
 
-    private :mocked_class
-
+    private(:mocked_class)
     def attribute_names
-      @attribute_names ||= %w(id name age admin created_at updated_at) | super
+      @attribute_names ||= (["id", "name", "age", "admin", "created_at", "updated_at"] | super)
     end
 
     def primary_key
@@ -44,7 +40,9 @@ class UserMock < ActiveMocker::Base
     def table_name
       "users" || super
     end
+
   end
+
   # _attributes.erb
   def id
     read_attribute(:id)
@@ -95,38 +93,40 @@ class UserMock < ActiveMocker::Base
   end
 
   # _associations.erb
-
   # has_many
   def comments
-    read_association(:comments, -> { ActiveMocker::HasMany.new([], foreign_key: "user_id", foreign_id: id, relation_class: classes("Comment"), source: "") })
+    read_association(:comments, lambda do
+      ActiveMocker::HasMany.new([], foreign_key: "user_id", foreign_id: self.id, relation_class: classes("Comment"), source: "")
+    end)
   end
 
   def comments=(val)
-    write_association(:comments, ActiveMocker::HasMany.new(val, foreign_key: "user_id", foreign_id: id, relation_class: classes("Comment"), source: ""))
+    write_association(:comments, ActiveMocker::HasMany.new(val, foreign_key: "user_id", foreign_id: self.id, relation_class: classes("Comment"), source: ""))
   end
 
   def subscriptions
-    read_association(:subscriptions, -> { ActiveMocker::HasMany.new([], foreign_key: "user_id", foreign_id: id, relation_class: classes("Subscription"), source: "") })
+    read_association(:subscriptions, lambda do
+      ActiveMocker::HasMany.new([], foreign_key: "user_id", foreign_id: self.id, relation_class: classes("Subscription"), source: "")
+    end)
   end
 
   def subscriptions=(val)
-    write_association(:subscriptions, ActiveMocker::HasMany.new(val, foreign_key: "user_id", foreign_id: id, relation_class: classes("Subscription"), source: ""))
+    write_association(:subscriptions, ActiveMocker::HasMany.new(val, foreign_key: "user_id", foreign_id: self.id, relation_class: classes("Subscription"), source: ""))
   end
 
   # _scopes.erb
   module Scopes
-    include ActiveMocker::Base::Scopes
+    include(ActiveMocker::Base::Scopes)
   end
 
-  extend Scopes
-
+  extend(Scopes)
   class ScopeRelation < ActiveMocker::Association
-    include UserMock::Scopes
+    include(UserMock::Scopes)
   end
 
   def self.__new_relation__(collection)
     UserMock::ScopeRelation.new(collection)
   end
 
-  private_class_method :__new_relation__
+  private_class_method(:__new_relation__)
 end

--- a/example_rails_app/spec/models/user_spec.rb
+++ b/example_rails_app/spec/models/user_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails_helper"
 require "spec/mocks/user_mock"
 
@@ -11,13 +12,13 @@ RSpec.describe User, no_db: true do
 
   context "with active mocker in use", active_mocker: true do
     it "doesn't touch the db with the nosql gem in use" do
-      expect{code.call}.not_to raise_error Nosql::Error
+      expect { code.call }.not_to raise_error Nosql::Error
     end
   end
 
   context "with active mocker in use", active_mocker: false do
     it "touches the db" do
-      expect{code.call}.to raise_error Nosql::Error, ["PRAGMA table_info(\"users\")", "SCHEMA"].inspect
+      expect { code.call }.to raise_error Nosql::Error, ["PRAGMA table_info(\"users\")", "SCHEMA"].inspect
     end
   end
 end

--- a/example_rails_app/spec/models/user_spec.rb
+++ b/example_rails_app/spec/models/user_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+require "spec/mocks/user_mock"
+
+RSpec.describe User, no_db: true do
+  let(:code) do
+    lambda do
+      user = User.create name: "Mark"
+      expect(user.reload.name).to eq "Mark"
+    end
+  end
+
+  context "with active mocker in use", active_mocker: true do
+    it "doesn't touch the db with the nosql gem in use" do
+      expect{code.call}.not_to raise_error Nosql::Error
+    end
+  end
+
+  context "with active mocker in use", active_mocker: false do
+    it "touches the db" do
+      expect{code.call}.to raise_error Nosql::Error, ["PRAGMA table_info(\"users\")", "SCHEMA"].inspect
+    end
+  end
+end

--- a/example_rails_app/spec/rails_helper.rb
+++ b/example_rails_app/spec/rails_helper.rb
@@ -12,4 +12,12 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.infer_spec_type_from_file_location!
+
+  require "nosql"
+  # ensure no database connections
+  config.around(:each, no_db: true) do |example|
+    Nosql::Connection.enable!
+    example.run
+    Nosql::Connection.disable!
+  end
 end

--- a/example_rails_app/spec/spec_helper.rb
+++ b/example_rails_app/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 $VERBOSE = nil # This removes ruby warnings
 require "active_mocker/rspec_helper"
 $LOAD_PATH.unshift File.join(File.expand_path("../../", __FILE__)) # add root of app to path
+
 RSpec.configure do |config|
   config.order = "random"
   config.mock_framework = :rspec


### PR DESCRIPTION
I've been trying to debug why our app is still hitting the db and thought I would confirm that active_mocker itself doesn't hit the db during tests when using mocks.

https://blog.pivotal.io/pivotal-labs/labs/testing-strategies-rspec-nulldb-nosql

Unfortunately for us, we confirmed that we can't see a problem in active_mocker.

As a side effect though, we have this test. Which might be useful for the example app.
But would you maybe rather have it in the actual test suites?